### PR TITLE
Add ability for  method to return dict instances which can contain li…

### DIFF
--- a/flatdict.py
+++ b/flatdict.py
@@ -130,7 +130,7 @@ class FlatDict(dict):
             raise TypeError("Can only return list representation if was previously a list!")
 
         list_out = []
-        for key in sorted(self._values.keys()):
+        for key in sorted(self._values.keys(), key=lambda x: int(x) if x.isdigit() else x):
             if key.isdigit():
                 list_index_of_key = int(key)
                 final_key = key

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 codecov
-coverage
+coverage==3.7.1
 nose

--- a/tests.py
+++ b/tests.py
@@ -447,3 +447,52 @@ class FlatDictSetDelimiterTests(FlatDictDelimiterTests):
         self.object = flatdict.FlatDict(self.VALUES, '^')
         self.object.set_delimiter('-')
         self.keys = sorted([k.replace(':', '-') for k in self.KEYS])
+
+
+class FlatDictListAwarenessTests(unittest.TestCase):
+
+    DOCUMENT = {
+        "admiring": "allen",
+        "wonderful": "archimedes",
+        "quirky": [
+            {
+                "nifty": "khorana",
+                "nostalgic": "lichterman",
+                "gallant": [
+                    "bhaskara",
+                    "darwin",
+                    "meninsky"
+                ]
+            },
+            {
+                "nifty": "jennings",
+                "nostalgic": "hermann",
+            },
+            "condescending liskov"
+        ],
+        "flamboyant": "swartz"
+    }
+
+    KEYS = [
+        'admiring',
+        'wonderful',
+        'quirky:0:nifty',
+        'quirky:0:nostalgic',
+        'quirky:0:gallant:0',
+        'quirky:0:gallant:1',
+        'quirky:0:gallant:2',
+        'quirky:1:nifty',
+        'quirky:1:nostalgic',
+        'quirky:2',
+        'flamboyant'
+    ]
+
+    def setUp(self):
+        self.dict = flatdict.FlatDict(self.DOCUMENT, as_dict_list_awareness=True)
+        self.keys = sorted(self.KEYS)
+
+    def test_flatten_keys_are_created_as_expected(self):
+        self.assertEqual(self.keys, sorted([key for key in self.dict]))
+
+    def test_as_dict_returns_object_with_properly_constructed_lists(self):
+        self.assertEqual(self.DOCUMENT, self.dict.as_dict())


### PR DESCRIPTION
Allow `as_dict` method to return dict instances containing lists.

**Function added**: If appropriate flag is set while instantiating *FlatDict* (`as_dict_list_awareness=True`) the `as_dict` method will no longer return dictionary with lists converted to dicts – instead it will contain lists.

Example: 
```python
# Dictionary containg dicts nested in list
document = {
    "eloquent": [
		{
		    "frosty": "dijkstra",
		    "happy": "dubinsky"
		}
    ]
}

import flatdict
old_flatdict = flatdict.FlatDict(document)
dict.as_dict()

Out: {'eloquent': ['dijkstra', 'dubinsky']}
# Information is lost and the dict structure is not preserved!

old_flatdict = flatdict.FlatDict(document, as_dict_list_awareness=True)
dict.as_dict()

Out: {'eloquent':[{'frosty':'dijkstra','happy':'dubinsky'}]}
# Information was not lost, dict structure is preserved.
```
**Rationale**: I am currently using *FlatDict* as a wrapper for objects read directly from JSON format – this makes many operations easier. However, currently there is no way to return to initial structure of document and save it back to JSON – with this change it becomes possible. 
