### PR TITLE
Implement __eq__ called in unittest.assertDictEqual. Fix unit tests.

### DIFF
--- a/flatdict.py
+++ b/flatdict.py
@@ -19,6 +19,12 @@ class FlatDict(dict):
     # Should as_dict method be aware of lists while building response
     AS_DICT_LIST_AWARENESS = False
 
+    def __eq__(self, other):
+        return set(self.items()) == set(other.items())
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def __init__(self, value=None, delimiter=None, former_type=dict, as_dict_list_awareness=None):
         super(FlatDict, self).__init__()
         self._values = {}

--- a/tests.py
+++ b/tests.py
@@ -226,12 +226,12 @@ class FlatDictTests(unittest.TestCase):
                                          'grault:baz': 3,
                                          'grault:qux': 4,
                                          'grault:corge': 5,
-                                         'foo:list:0': 'F',
-                                         'foo:list:1': 'O',
-                                         'foo:list:2': 'O',
-                                         'foo:tuple:0': 'F',
-                                         'foo:tuple:1': 0,
-                                         'foo:tuple:2': 0})
+                                         'list:0': 'F',
+                                         'list:1': 'O',
+                                         'list:2': 'O',
+                                         'tuple:0': 'F',
+                                         'tuple:1': 0,
+                                         'tuple:2': 0})
         response = self.object.pop(key)
         self.assertDictEqual(response, expectation)
         self.assertTrue(key not in self.object)
@@ -408,12 +408,12 @@ class FlatDictDelimiterTests(FlatDictTests):
                                          'grault-baz': 3,
                                          'grault-qux': 4,
                                          'grault-corge': 5,
-                                         'foo:list:0': 'F',
-                                         'foo:list:1': 'O',
-                                         'foo:list:2': 'O',
-                                         'foo:tuple:0': 'F',
-                                         'foo:tuple:1': 0,
-                                         'foo:tuple:2': 0})
+                                         'list-0': 'F',
+                                         'list-1': 'O',
+                                         'list-2': 'O',
+                                         'tuple-0': 'F',
+                                         'tuple-1': 0,
+                                         'tuple-2': 0})
         response = self.object.pop(key)
         self.assertDictEqual(response, expectation)
         self.assertTrue(key not in self.object)
@@ -429,12 +429,12 @@ class FlatDictDelimiterTests(FlatDictTests):
                                          'garply-bar': 1,
                                          'garply-baz': 2,
                                          'garply-qux-corge': 3,
-                                         'foo:list:0': 'F',
-                                         'foo:list:1': 'O',
-                                         'foo:list:2': 'O',
-                                         'foo:tuple:0': 'F',
-                                         'foo:tuple:1': 0,
-                                         'foo:tuple:2': 0})
+                                         'foo-list-0': 'F',
+                                         'foo-list-1': 'O',
+                                         'foo-list-2': 'O',
+                                         'foo-tuple-0': 'F',
+                                         'foo-tuple-1': 0,
+                                         'foo-tuple-2': 0})
         self.object.update({'foo-bar-baz': 4,
                             'foo-bar-qux': 5,
                             'foo-bar-corge': 6})


### PR DESCRIPTION
Tests are calling unittest.assertDictEqual but not implementing __eq__/__ne__. Fixed failing tests.