### PR TITLE
Empty iterable fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.1.0 (2018-10-30)
+- FIXED `FlatDict` behavior with empty iteratable values
+- CHANGED behavior when casting to str or repr (#23)
+
+## 3.0.1 (2018-07-01)
+- Add 3.7 to Trove Classifiers
+- Add Python 2.7 unicode string compatibility (#22 [nvllsvm](https://github.com/nvllsvm))
+
 ## 3.0.0 (2018-03-06)
 - CHANGED `FlatDict.as_dict` to return the nested data structure based upon delimiters, coercing `FlatDict` objects to `dict`.
 - CHANGED `FlatDict` to extend `collections.MutableMapping` instead of dict

--- a/flatdict.py
+++ b/flatdict.py
@@ -4,7 +4,7 @@ key/value pair mapping of nested dictionaries.
 """
 import collections
 
-__version__ = '3.0.1'
+__version__ = '3.1.0'
 
 NO_DEFAULT = object()
 

--- a/flatdict.py
+++ b/flatdict.py
@@ -284,7 +284,8 @@ class FlatDict(collections.MutableMapping):
         keys = []
         for key, value in self._values.items():
             if isinstance(value, (FlatDict, dict)):
-                keys += [self._delimiter.join([key, k]) for k in value.keys()]
+                nested = [self._delimiter.join([key, k]) for k in value.keys()]
+                keys += nested if nested else [key]
             else:
                 keys.append(key)
         return sorted(keys)

--- a/flatdict.py
+++ b/flatdict.py
@@ -130,7 +130,8 @@ class FlatDict(collections.MutableMapping):
         :rtype: str
 
         """
-        return '"{}"'.format(str(self))
+        return '<{} id={} {}>"'.format(
+            self.__class__.__name__, id(self), str(self))
 
     def __setitem__(self, key, value):
         """Assign the value to the key, dynamically building nested
@@ -161,10 +162,8 @@ class FlatDict(collections.MutableMapping):
         :rtype: str
 
         """
-        return '{{{}}}'.format(', '.join([
-            '{!r}: {!r}'.format(str(k), str(v))
-            for k, v in sorted(self.items())
-        ]))
+        return '{{{}}}'.format(', '.join(
+            ['{!r}: {!r}'.format(k, self[k]) for k in self.keys()]))
 
     def as_dict(self):
         """Return the :class:`~flatdict.FlatDict` as a :class:`dict`

--- a/tests.py
+++ b/tests.py
@@ -285,6 +285,12 @@ class FlatDictTests(unittest.TestCase):
         flat[u'key1:key2'] = u'value1'
         self.assertEqual(flat.as_dict(), {'key1': {'key2': 'value1'}})
 
+    def test_empty_dict_as_value(self):
+        expectation = {'foo': {'bar': {}}}
+        flat = self.TEST_CLASS(expectation)
+        value = flat.as_dict()
+        self.assertDictEqual(value, expectation)
+
 
 class FlatterDictTests(FlatDictTests):
 

--- a/tests.py
+++ b/tests.py
@@ -164,12 +164,14 @@ class FlatDictTests(unittest.TestCase):
             sorted(self.KEYS), sorted([k for k in iter(self.value)]))
 
     def test_repr_value(self):
-        val = self.TEST_CLASS({'foo': 'bar', 'baz': {'qux': 'corgie'}})
-        self.assertEqual("\"{'baz:qux': 'corgie', 'foo': 'bar'}\"", repr(val))
+        value = self.TEST_CLASS({'foo': 'bar', 'baz': {'qux': 'corgie'}})
+        self.assertIn(str(value), repr(value))
+        self.assertEqual(repr(value)[0:len(self.TEST_CLASS.__name__) + 1],
+                         '<{}'.format(self.TEST_CLASS.__name__))
 
     def test_str_value(self):
-        val = self.TEST_CLASS({'foo': 'bar', 'baz': {'qux': 'corgie'}})
-        self.assertEqual("{'baz:qux': 'corgie', 'foo': 'bar'}", str(val))
+        val = self.TEST_CLASS({'foo': 1, 'baz': {'qux': 'corgie'}})
+        self.assertEqual("{'baz:qux': 'corgie', 'foo': 1}", str(val))
 
     def test_incorrect_assignment_raises(self):
         value = self.TEST_CLASS({'foo': ['bar'], 'qux': 1})


### PR DESCRIPTION
This PR adds a fix for when an empty dict lives at the bottom level fo a tree. The keys would not be properly returned.

Also slightly cleans up str and repr to make them less confusing.