### PR TITLE
Keep correct key order and values when flatdict has nested list

### DIFF
--- a/flatdict.py
+++ b/flatdict.py
@@ -477,7 +477,7 @@ class FlatterDict(FlatDict):
         if any(self._has_delimiter(k) for k in keys):
             out = []
             split_keys = [k.split(self._delimiter)[0] for k in keys]
-            for k in sorted(set(split_keys)):
+            for k in sorted(set(split_keys), key=lambda x: int(x)):
                 if subset[k].original_type == tuple:
                     out.append(tuple(self._child_as_list(pk, k)))
                 elif subset[k].original_type == list:

--- a/flatdict.py
+++ b/flatdict.py
@@ -477,7 +477,7 @@ class FlatterDict(FlatDict):
         if any(self._has_delimiter(k) for k in keys):
             out = []
             split_keys = [k.split(self._delimiter)[0] for k in keys]
-            for k in sorted(set(split_keys), key=lambda x: int(x)):
+            for k in sorted(set(split_keys)):
                 if subset[k].original_type == tuple:
                     out.append(tuple(self._child_as_list(pk, k)))
                 elif subset[k].original_type == list:

--- a/tests.py
+++ b/tests.py
@@ -226,7 +226,7 @@ class FlatDictTests(unittest.TestCase):
 
     def test_iter_items(self):
         items = [(k, v) for k, v in self.value.iteritems()]
-        self.assertEqual(sorted(self.value.items()), items)
+        self.assertEqual(self.value.items(), items)
 
     def test_iterkeys(self):
         keys = [k for k in self.value.iterkeys()]
@@ -327,6 +327,15 @@ class FlatterDictTests(FlatDictTests):
         'foo:list:0': 'F',
         'foo:list:1': 'O',
         'foo:list:2': 'O',
+        'foo:list:3': '',
+        'foo:list:4': 'B',
+        'foo:list:5': 'A',
+        'foo:list:6': 'R',
+        'foo:list:7': '',
+        'foo:list:8': 'L',
+        'foo:list:9': 'I',
+        'foo:list:10': 'S',
+        'foo:list:11': 'T',
         'foo:set:0': 10,
         'foo:set:1': 20,
         'foo:set:2': 30,
@@ -355,46 +364,55 @@ class FlatterDictTests(FlatDictTests):
         'double_nest:2:1': 6,
     }
 
-    KEYS = sorted([
-        'foo:bar:baz',
-        'foo:bar:qux',
-        'foo:bar:corge',
-        'foo:bar:list:0',
-        'foo:bar:list:1',
-        'foo:bar:list:2',
-        'foo:grault:baz',
-        'foo:grault:qux',
-        'foo:grault:corge',
-        'foo:list:0',
-        'foo:list:1',
-        'foo:list:2',
-        'foo:set:0',
-        'foo:set:1',
-        'foo:set:2',
-        'foo:tuple:0',
-        'foo:tuple:1',
-        'foo:tuple:2',
-        'garply:foo',
-        'garply:bar',
-        'garply:baz',
-        'garply:qux:corge',
-        'fred',
-        'thud',
-        'xyzzy',
-        'waldo:fred',
-        'waldo:wanda',
-        'foo:abc:def',
-        'neighbors:0:left',
-        'neighbors:0:right',
-        'neighbors:1:left',
-        'neighbors:1:right',
+    KEYS = [
         'double_nest:0:0',
         'double_nest:0:1',
         'double_nest:1:0',
         'double_nest:1:1',
         'double_nest:2:0',
         'double_nest:2:1',
-    ])
+        'foo:abc:def',
+        'foo:bar:baz',
+        'foo:bar:corge',
+        'foo:bar:list:0',
+        'foo:bar:list:1',
+        'foo:bar:list:2',
+        'foo:bar:qux',
+        'foo:grault:baz',
+        'foo:grault:corge',
+        'foo:grault:qux',
+        'foo:list:0',
+        'foo:list:1',
+        'foo:list:2',
+        'foo:list:3',
+        'foo:list:4',
+        'foo:list:5',
+        'foo:list:6',
+        'foo:list:7',
+        'foo:list:8',
+        'foo:list:9',
+        'foo:list:10',
+        'foo:list:11',
+        'foo:set:0',
+        'foo:set:1',
+        'foo:set:2',
+        'foo:tuple:0',
+        'foo:tuple:1',
+        'foo:tuple:2',
+        'fred',
+        'garply:bar',
+        'garply:baz',
+        'garply:foo',
+        'garply:qux:corge',
+        'neighbors:0:left',
+        'neighbors:0:right',
+        'neighbors:1:left',
+        'neighbors:1:right',
+        'thud',
+        'waldo:fred',
+        'waldo:wanda',
+        'xyzzy',
+    ]
 
     VALUES = {
         'foo': {
@@ -409,7 +427,7 @@ class FlatterDictTests(FlatDictTests):
                 'qux': 4,
                 'corge': 5
             },
-            'list': ['F', 'O', 'O'],
+            'list': ['F', 'O', 'O', '', 'B', 'A', 'R', '', 'L', 'I', 'S', 'T'],
             'set': {10, 20, 30},
             'tuple': ('F', 0, 0),
             'abc': {
@@ -461,7 +479,7 @@ class FlatterDictTests(FlatDictTests):
                 'qux': 4,
                 'corge': 5
             },
-            'list': ['F', 'O', 'O'],
+            'list': ['F', 'O', 'O', '', 'B', 'A', 'R', '', 'L', 'I', 'S', 'T'],
             'set': {10, 20, 30},
             'tuple': ('F', 0, 0),
             'abc': {


### PR DESCRIPTION
How to reproduce:

```python
import flatdict
from pprint import pprint

dd = {
    "inputs": [
        {"name": 0},
        {"name": 1},
        {"name": 2},
        {"name": 3},
        {"name": 4},
        {"name": 5},
        {"name": 6},
        {"name": 7},
        {"name": 8},
        {"name": 9},
        {"name": 10},
    ],
}

fd = flatdict.FlatterDict(dd)
pprint(fd.keys())
pprint(fd.as_dict())
```

**Output from 3.3.0**

```python
['inputs:0:name',
 'inputs:10:name',
 'inputs:1:name',
 'inputs:2:name',
 'inputs:3:name',
 'inputs:4:name',
 'inputs:5:name',
 'inputs:6:name',
 'inputs:7:name',
 'inputs:8:name',
 'inputs:9:name']
{'inputs': [{'name': 0},
            {'name': 1},
            {'name': 10},
            {'name': 2},
            {'name': 3},
            {'name': 4},
            {'name': 5},
            {'name': 6},
            {'name': 7},
            {'name': 8},
            {'name': 9}]}
```

**Expected output**

```python
['inputs:0:name',
 'inputs:1:name',
 'inputs:2:name',
 'inputs:3:name',
 'inputs:4:name',
 'inputs:5:name',
 'inputs:6:name',
 'inputs:7:name',
 'inputs:8:name',
 'inputs:9:name',
 'inputs:10:name']
{'inputs': [{'name': 0},
            {'name': 1},
            {'name': 2},
            {'name': 3},
            {'name': 4},
            {'name': 5},
            {'name': 6},
            {'name': 7},
            {'name': 8},
            {'name': 9},
            {'name': 10}]}
```