### PR TITLE
Fixed key/items order.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ jobs:
   - python: "3.5"
   - python: "3.6"
   - python: "3.7"
+  - python: "3.8"
   - python: pypy
   - python: pypy3
   - stage: coverage
@@ -36,7 +37,7 @@ jobs:
     script: ci/combine-coverage.sh
   - stage: deploy
     if: repo = gmr/flatdict
-    python: "3.7"
+    python: "3.8"
     services: []
     install: true
     before_script: []

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ after_success:
 
 jobs:
   include:
-  - python: "2.7"
   - python: "3.4"
   - python: "3.5"
   - python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ after_success:
 
 jobs:
   include:
-  - python: "3.4"
   - python: "3.5"
   - python: "3.6"
   - python: "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ jobs:
   - python: "3.6"
   - python: "3.7"
   - python: "3.8"
-  - python: pypy
   - python: pypy3
   - stage: coverage
     if: repo = gmr/flatdict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.5.0 (2019-12-30)
+## 4.0.0 (2019-12-30)
 
 - FIXED keep order of received dict and it's nested objects
 - Drops Python 2 support and Python 3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.5.0 (2019-12-30)
+
+- FIXED keep order of received dict and it's nested objects
+
 ## 3.4.0 (2019-07-24)
 
 - FIXED sort order with regard to a nested list of dictionaries (#33 [wsantos](https://github.com/wsantos))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.5.0 (2019-12-30)
 
 - FIXED keep order of received dict and it's nested objects
-- Drops python 2 support
+- Drops Python 2 support and Python 3.4
 
 ## 3.4.0 (2019-07-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.5.0 (2019-12-30)
 
 - FIXED keep order of received dict and it's nested objects
+- Drops python 2 support
 
 ## 3.4.0 (2019-07-24)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,32 +4,13 @@
 
 Use of virtual environments will allow for isolated installation of testing requirements:
 
-###Python 2
-
 ```bash
-virtualenv -p python2.7 env27
-source env/bin/activate
-pip install -r test-requirements
-```
-
-###Python 3
-
-```bash
-python3 -m venv env
+python -m venv env
 source env/bin/activate
 pip install -r test-requirements
 ```
 
 ## Running Tests
-
-###Python 2
-
-```bash
-source env27/bin/activate
-./ci/test.sh
-```
-
-###Python 3
 
 ```bash
 source env/bin/activate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 Use of virtual environments will allow for isolated installation of testing requirements:
 
 ```bash
-python -m venv env
+python3 -m venv env
 source env/bin/activate
 pip install -r test-requirements
 ```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ FlatDict
 |Version| |Status| |Coverage| |License|
 
 ``flatdict`` is a Python module for interacting with nested dicts as a single
-level dict with delimited keys. ``flatdict`` supports Python 2.7+ and 3.4+.
+level dict with delimited keys. ``flatdict`` supports Python 3.4+.
 
 Jump to :ref:`installation`, :ref:`example`, or :ref:`docs`.
 

--- a/flatdict.py
+++ b/flatdict.py
@@ -478,7 +478,9 @@ class FlatterDict(FlatDict):
                     out.append(subset[k].as_dict())
             return out
 
-        if sys.version_info[0:2] <= (3, 5):
+        # Python prior 3.6 don't guarantee insertion order, remove it after
+        # EOL python 3.5 - 2020-09-13
+        if sys.version_info[0:2] < (3, 6):
             return [subset[k] for k in sorted(keys, key=lambda x: int(x))]
         else:
             return [subset[k] for k in keys]

--- a/flatdict.py
+++ b/flatdict.py
@@ -3,6 +3,7 @@ key/value pair mapping of nested dictionaries.
 
 """
 import collections
+import sys
 
 __version__ = '3.5.0'
 
@@ -482,4 +483,8 @@ class FlatterDict(FlatDict):
                 elif subset[k].original_type == dict:
                     out.append(subset[k].as_dict())
             return out
-        return [subset[k] for k in keys]
+
+        if sys.version_info[0:2] <= (3, 5):
+            return [subset[k] for k in sorted(keys, key=lambda x: int(x))]
+        else:
+            return [subset[k] for k in keys]

--- a/flatdict.py
+++ b/flatdict.py
@@ -5,15 +5,9 @@ key/value pair mapping of nested dictionaries.
 import collections
 import sys
 
-__version__ = '3.5.0'
+__version__ = '4.0.0'
 
 NO_DEFAULT = object()
-
-# Python 2/3 string compat
-try:
-    basestring
-except NameError:
-    basestring = str
 
 
 class FlatDict(collections.MutableMapping):
@@ -373,7 +367,7 @@ class FlatDict(collections.MutableMapping):
         :rtype: bool
 
         """
-        return isinstance(key, basestring) and self._delimiter in key
+        return isinstance(key, str) and self._delimiter in key
 
 
 class FlatterDict(FlatDict):

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,6 @@ classifiers =
     License :: OSI Approved :: BSD License
     Operating System :: POSIX
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5

--- a/tests.py
+++ b/tests.py
@@ -39,13 +39,13 @@ class FlatDictTests(unittest.TestCase):
         'waldo:wanda': 7
     }
 
-    KEYS = sorted([
+    KEYS = [
         'foo:bar:baz', 'foo:bar:qux', 'foo:bar:corge', 'foo:grault:baz',
         'foo:grault:qux', 'foo:grault:corge', 'foo:list', 'foo:empty_list',
         'foo:set', 'foo:empty_set', 'foo:tuple', 'foo:empty_tuple',
         'garply:foo', 'garply:bar', 'garply:baz', 'garply:qux:corge', 'fred',
-        'thud', 'xyzzy', 'waldo:fred', 'waldo:wanda'
-    ])
+        'xyzzy', 'thud', 'waldo:fred', 'waldo:wanda'
+    ]
 
     VALUES = {
         'foo': {
@@ -182,7 +182,7 @@ class FlatDictTests(unittest.TestCase):
 
     def test_str_value(self):
         val = self.TEST_CLASS({'foo': 1, 'baz': {'qux': 'corgie'}})
-        self.assertEqual("{'baz:qux': 'corgie', 'foo': 1}", str(val))
+        self.assertEqual("{'foo': 1, 'baz:qux': 'corgie'}", str(val))
 
     def test_incorrect_assignment_raises(self):
         value = self.TEST_CLASS({'foo': ['bar'], 'qux': 1})
@@ -365,22 +365,15 @@ class FlatterDictTests(FlatDictTests):
     }
 
     KEYS = [
-        'double_nest:0:0',
-        'double_nest:0:1',
-        'double_nest:1:0',
-        'double_nest:1:1',
-        'double_nest:2:0',
-        'double_nest:2:1',
-        'foo:abc:def',
         'foo:bar:baz',
+        'foo:bar:qux',
         'foo:bar:corge',
         'foo:bar:list:0',
         'foo:bar:list:1',
         'foo:bar:list:2',
-        'foo:bar:qux',
         'foo:grault:baz',
-        'foo:grault:corge',
         'foo:grault:qux',
+        'foo:grault:corge',
         'foo:list:0',
         'foo:list:1',
         'foo:list:2',
@@ -399,19 +392,26 @@ class FlatterDictTests(FlatDictTests):
         'foo:tuple:0',
         'foo:tuple:1',
         'foo:tuple:2',
-        'fred',
+        'foo:abc:def',
+        'garply:foo',
         'garply:bar',
         'garply:baz',
-        'garply:foo',
         'garply:qux:corge',
+        'fred',
+        'xyzzy',
+        'thud',
+        'waldo:fred',
+        'waldo:wanda',
         'neighbors:0:left',
         'neighbors:0:right',
         'neighbors:1:left',
         'neighbors:1:right',
-        'thud',
-        'waldo:fred',
-        'waldo:wanda',
-        'xyzzy',
+        'double_nest:0:0',
+        'double_nest:0:1',
+        'double_nest:1:0',
+        'double_nest:1:1',
+        'double_nest:2:0',
+        'double_nest:2:1',
     ]
 
     VALUES = {
@@ -442,16 +442,11 @@ class FlatterDictTests(FlatDictTests):
                 'corge': 3
             }
         },
-        'fred':
-        4,
-        'xyzzy':
-        'plugh',
-        'thud':
-        5,
-        'waldo:fred':
-        6,
-        'waldo:wanda':
-        7,
+        'fred': 4,
+        'xyzzy': 'plugh',
+        'thud': 5,
+        'waldo:fred': 6,
+        'waldo:wanda': 7,
         'neighbors': [{
             'left': 'john',
             'right': 'michelle'

--- a/tests.py
+++ b/tests.py
@@ -190,7 +190,7 @@ class FlatDictTests(unittest.TestCase):
             self.assertIn("'foo': 1", str(val))
             self.assertIn("'baz:qux': 'corgie'", str(val))
         else:
-            self.assertEqual("{'baz:qux': 'corgie', 'foo': 1}", str(val))
+            self.assertEqual("{'foo': 1, 'baz:qux': 'corgie'}", str(val))
 
     def test_incorrect_assignment_raises(self):
         value = self.TEST_CLASS({'foo': ['bar'], 'qux': 1})

--- a/tests.py
+++ b/tests.py
@@ -148,8 +148,8 @@ class FlatDictTests(unittest.TestCase):
 
     def test_as_dict(self):
         if sys.version_info <= (3, 5):
-            self.assertFalse(set(
-                self.value.as_dict().items() ^ self.AS_DICT.items()))
+            self.assertCountEqual(
+                self.value.as_dict().items(), self.AS_DICT.items())
         else:
             self.assertDictEqual(self.value.as_dict(), self.AS_DICT)
 

--- a/tests.py
+++ b/tests.py
@@ -229,11 +229,11 @@ class FlatDictTests(unittest.TestCase):
         self.assertEqual(self.value.items(), items)
 
     def test_iterkeys(self):
-        keys = [k for k in self.value.iterkeys()]
+        keys = list(self.value.iterkeys())
         self.assertEqual(keys, self.KEYS)
 
     def test_itervalues(self):
-        values = [v for v in self.value.itervalues()]
+        values = list(self.value.itervalues())
         self.assertEqual(values, self.value.values())
 
     def test_pop(self):


### PR DESCRIPTION
I've made some tweaks on how we handle sorting and I strongly think that is not the scope of the library and can easily be done by the user of the module, with this change we simplified the code and improved performance for huge dicts with huge lists

Since this is changing a behavior I've bumped to 3.5, I've found another small issues but I'm going to create issues so we can also receive help from others.

Closes #37
Fixes #36  
Fixes #35