### PR TITLE
Add `guess_lists` option when unflattening FlatterDict

### DIFF
--- a/flatdict.py
+++ b/flatdict.py
@@ -468,7 +468,7 @@ class FlatterDict(FlatDict):
                     break
                 keys_as_nums.append(int(key))
             if all_keys_int and keys_as_nums == list(range(len(keys_as_nums))):
-                out = list(out.values())
+                out = [out[str(k)] for k in range(len(keys_as_nums))]
 
         return out
 

--- a/flatdict.py
+++ b/flatdict.py
@@ -444,7 +444,7 @@ class FlatterDict(FlatDict):
                     elif self._values[pk].original_type == set:
                         out[pk] = set(self._child_as_list(pk))
                     elif self._values[pk].original_type == dict:
-                        out[pk] = self._values[pk].as_dict()
+                        out[pk] = self._values[pk].as_dict(guess_lists=guess_lists)
             else:
                 if isinstance(self._values[key], FlatterDict):
                     out[key] = self._values[key].original_type()

--- a/flatdict.py
+++ b/flatdict.py
@@ -423,7 +423,7 @@ class FlatterDict(FlatDict):
         else:
             self._values[key] = value
 
-    def as_dict(self):
+    def as_dict(self, guess_lists=False):
         """Return the :class:`~flatdict.FlatterDict` as a nested
         :class:`dict`.
 
@@ -450,6 +450,26 @@ class FlatterDict(FlatDict):
                     out[key] = self._values[key].original_type()
                 else:
                     out[key] = self._values[key]
+
+        if guess_lists:
+            # if all `out` keys:
+            # - are strings,
+            # - can be converted to ints, and
+            # - and represent a continuous range from 0
+            # then make it a list
+            all_keys_int = True
+            keys_as_nums = []
+            for key in out.keys():
+                if not isinstance(key, str):
+                    all_keys_int = False
+                    break
+                if not key.isdigit():
+                    all_keys_int = False
+                    break
+                keys_as_nums.append(int(key))
+            if all_keys_int and keys_as_nums == list(range(len(keys_as_nums))):
+                out = list(out.values())
+
         return out
 
     def _child_as_list(self, pk, ck=None):


### PR DESCRIPTION
Add a `guess_lists` which, when unflattening a `FlatterDict` which contains no information about `original_types`, attempts to guess which of its sub-dicts should actually be lists.

Addresses #49 

A sub-dict should be a list if:
- all of its keys are strings
- all of its keys can be converted to integers
- the keys represent a contiguous sequence of integers, i.e., 0, 1, 2, 3, ... n