### PR TITLE
MANIFEST.in: Add tests.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include CHANGELOG.md README.rst LICENSE
+include tests.py


### PR DESCRIPTION
Tests should be included in source distribution.
This is allows for test to be fund and run with the Gentoo Linux package manager.