### PR TITLE
Fix bug when calling as_dict on empty dict

### DIFF
--- a/flatdict.py
+++ b/flatdict.py
@@ -183,7 +183,10 @@ class FlatDict(MutableMapping):
                 else:
                     out[pk][ck] = self._values[pk][ck]
             else:
-                out[key] = self._values[key]
+                if isinstance(self._values[key], FlatDict):
+                    out[key] = self._values[key].as_dict()
+                else:
+                    out[key] = self._values[key]
         return out
 
     def clear(self):

--- a/tests.py
+++ b/tests.py
@@ -535,3 +535,11 @@ class FlatterDictTests(FlatDictTests):
         vals['dicts'][0]['a'] = -1
         d.update(vals)
         self.assertEqual(d.as_dict(), vals)
+
+    def test_empty_dict_as_dict(self):
+        vals = {'dicts': [{'a': {'b': {'c': {}}}, 'd': 2}]}
+        d = self.TEST_CLASS(vals)
+        d.update(vals)
+        value = d.as_dict()['dicts'][0]['a']['b']['c']
+        self.assertEqual(value, {})
+        self.assertEqual(isinstance(value, dict), True)


### PR DESCRIPTION


```print(FlatDict({'a': {}}).as_dict())```

should produce 

```{'a': {}}```

but instead produces

```{'a': <FlatDict id=139834437272912 {}>"}```

This change fixes the functionality to print the former.
